### PR TITLE
Fix for issue: "can't open certificate"

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -16,7 +16,6 @@ FROM {ARG_FROM}
 
 ADD bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
-# This would be nicer as `nobody:nobody` but distroless has no such entries.
-USER 65535:65535
+# not using nobody as exporter needs permission to access certificate files
 
 ENTRYPOINT ["/{ARG_BIN}"]


### PR DESCRIPTION
Removed docker user `nobody`, runs as `root` now as the client-certificate key doesn't support permission over 600, and `root` is the owner of the mounted certificate-secret.